### PR TITLE
Only allow absolute URLs for shortening

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # **URL Shortening Service (Go)**
 
-![Coverage](https://img.shields.io/badge/Coverage-55.1%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-55.7%25-yellow)
 
 Create short URLs, resolve shortened URLs, and fetch all shortened URLs.
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -161,8 +161,29 @@ func TestPOSTLinkIntegration(t *testing.T) {
 		testutil.AssertContains(t, secondResp.Body.String(), `code: "123" already in use`)
 	})
 
-	t.Run("reuses code if no 'originalUrl' field matches an existing link", func(t *testing.T) {
-		t.Skip("TODO")
+	t.Run("errors if 'originalUrl' is not an absolute URL", func(t *testing.T) {
+		store := &mongodb.Store{
+			Client:        dbClient,
+			DBName:        dbName,
+			LinksCollName: urlCollName,
+		}
+		service := handlers.NewAPIService(handlers.ServiceConfig{
+			Store:  store,
+			APIkey: "test-api-key",
+		})
+		server := handlers.NewServer(service)
+
+		request := NewRequestWithAPIKey(
+			http.MethodPost,
+			"/api/urls/",
+			strings.NewReader(`{"originalUrl": "aol.com"}`),
+		)
+		response := httptest.NewRecorder()
+
+		server.ServeHTTP(response, request)
+
+		testutil.AssertStatus(t, response.Code, http.StatusBadRequest)
+		testutil.AssertResponseBody(t, response.Body.String(), "Relative URLs are not supported. URL must be absolute.")
 	})
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -176,14 +176,18 @@ func TestPOSTLinkIntegration(t *testing.T) {
 		request := NewRequestWithAPIKey(
 			http.MethodPost,
 			"/api/urls/",
-			strings.NewReader(`{"originalUrl": "aol.com"}`),
+			strings.NewReader(`{"originalUrl": "altavista.com"}`),
 		)
 		response := httptest.NewRecorder()
 
 		server.ServeHTTP(response, request)
 
 		testutil.AssertStatus(t, response.Code, http.StatusBadRequest)
-		testutil.AssertResponseBody(t, response.Body.String(), "Relative URLs are not supported. URL must be absolute.")
+		testutil.AssertResponseBody(
+			t,
+			response.Body.String(),
+			`URL: "altavista.com" is relative. URLs must be absolute`+"\n",
+		)
 	})
 }
 

--- a/shorty/errors.go
+++ b/shorty/errors.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 )
 
-var ErrLinkNotFound = errors.New("Link not found")
-var ErrJSONUnmarshal = errors.New("Cannot parse Link JSON")
-var ErrCodeInUse = errors.New("Code already in use")
+var ErrLinkNotFound = errors.New("link not found")
+var ErrJSONUnmarshal = errors.New("cannot parse Link JSON")
+var ErrCodeInUse = errors.New("code already in use")
+var ErrRelativeURL = errors.New("URL is relative")
+var ErrInvalidURL = errors.New("URL improperly formatted")


### PR DESCRIPTION
Resolves #14 
Do not allow relative URLs when creating short links.