### PR TITLE
Feat/url tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,25 @@ Loosely based on Nic Jackson's [microservice tutorials](https://github.com/nicho
 type Link struct {
   // Shortened URL result. Ex: https://ospk.org/bas12d21dc.
   ShortURL string `json:"shortUrl" bson:"shortUrl"`
+
   // Short Code used as the path of the short URL. Ex: bas12d21dc.
   Code string `json:"code" bson:"code"`
+
   // Optional custom short code passed when creating or updating the short URL.
   CustomCode string `json:"customCode" bson:"customCode"`
+
   // The URL where the short URL redirects.
   OriginalUrl string `json:"originalUrl" bson:"originalUrl"`
+
   // Count of times the short URL has been used.
   TotalClicks int `json:"totalClicks" bson:"totalClicks"`
+
   // Identifier of the entity that created the short URL.
   CreatedBy string `json:"createdBy" bson:"createdBy"`
+
   // DateTime the URL was created.
   CreatedAt time.Time `json:"createdAt" bson:"createdAt"`
+
   // DateTime the URL was last updated.
   UpdatedAt time.Time `json:"updatedAt" bson:"updatedAt"`
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # **URL Shortening Service (Go)**
 
-![Coverage](https://img.shields.io/badge/Coverage-51.4%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-56.0%25-yellow)
 
 Create short URLs, resolve shortened URLs, and fetch all shortened URLs.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # **URL Shortening Service (Go)**
 
-![Coverage](https://img.shields.io/badge/Coverage-55.7%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-56.1%25-yellow)
 
 Create short URLs, resolve shortened URLs, and fetch all shortened URLs.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # **URL Shortening Service (Go)**
 
-![Coverage](https://img.shields.io/badge/Coverage-56.1%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-51.4%25-yellow)
 
 Create short URLs, resolve shortened URLs, and fetch all shortened URLs.
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,7 +20,10 @@ func main() {
 	if envPort := os.Getenv("PORT"); envPort != "" {
 		port = envPort
 	}
+	println("Server started at http://localhost:" + port)
+
 	if err := funcframework.Start(port); err != nil {
 		log.Fatalf("funcframework.Start: %v\n", err)
 	}
+
 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -358,12 +358,25 @@ func parseLinkCode(URLPath string) *ShortCodeData {
 	path = strings.TrimPrefix(path, "/")
 	codes := strings.Split(path, "/")
 
-	codeData := &ShortCodeData{
+	if len(codes) == 0 {
+		return &ShortCodeData{
+			code: "",
+			tag:  "",
+		}
+	}
+
+	if len(codes) == 1 {
+		return &ShortCodeData{
+			code: codes[0],
+			tag:  "",
+		}
+	}
+
+	return &ShortCodeData{
 		code: codes[0],
 		tag:  codes[1],
 	}
 
-	return codeData
 }
 
 func validateURL(toShorten string) error {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -178,10 +178,6 @@ func (s *ShortyService) ServeResolver(w http.ResponseWriter, r *http.Request) {
 
 	codeData := parseLinkCode(r.URL.Path)
 
-	// TODO: Delete logs when feature is implemented
-	fmt.Printf("codeData.code: '%s'\n", codeData.code)
-	fmt.Printf("codeData.tag: '%s'\n", codeData.tag)
-
 	link, err := s.store.FindLink(r.Context(), codeData.code)
 	if err != nil {
 		if err == shorty.ErrLinkNotFound {
@@ -354,10 +350,12 @@ func (s *ShortyService) deleteLink(w http.ResponseWriter, r *http.Request) {
 
 func parseLinkCode(URLPath string) *ShortCodeData {
 	// parse code and tag from link path ex: /api/urls/abc123/tag
-	path := strings.TrimPrefix(URLPath, "/api/urls/")
-	path = strings.TrimPrefix(path, "/")
+	path := strings.TrimPrefix(URLPath, "/api/urls")
+	path = strings.Trim(path, "/")
+
 	codes := strings.Split(path, "/")
 
+	println("")
 	if len(codes) == 0 {
 		return &ShortCodeData{
 			code: "",

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -43,6 +43,11 @@ type (
 		APIkey      string
 		ErrorClient *errorreporting.Client
 	}
+
+	ShortCodeData struct {
+		code string
+		tag  string
+	}
 )
 
 func NewAPIService(c ServiceConfig) *ShortyService {
@@ -143,8 +148,8 @@ func (s *ShortyService) ServeAPI(w http.ResponseWriter, r *http.Request) {
 		return
 
 	case http.MethodGet:
-		code := parseLinkCode(r.URL.Path)
-		if len(code) == 0 {
+		codeData := parseLinkCode(r.URL.Path)
+		if len(codeData.code) == 0 {
 			s.getLinks(w, r)
 			return
 		}
@@ -171,8 +176,13 @@ func (s *ShortyService) ServeResolver(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	code := parseLinkCode(r.URL.Path)
-	link, err := s.store.FindLink(r.Context(), code)
+	codeData := parseLinkCode(r.URL.Path)
+
+	// TODO: Delete logs when feature is implemented
+	fmt.Printf("codeData.code: '%s'\n", codeData.code)
+	fmt.Printf("codeData.tag: '%s'\n", codeData.tag)
+
+	link, err := s.store.FindLink(r.Context(), codeData.code)
 	if err != nil {
 		if err == shorty.ErrLinkNotFound {
 			s.renderNotFound(w, r)
@@ -182,7 +192,7 @@ func (s *ShortyService) ServeResolver(w http.ResponseWriter, r *http.Request) {
 		s.logError(fmt.Errorf("findLink: %v", err), s.getTrace(r))
 	}
 
-	_, err = s.store.IncrementTotalClicks(r.Context(), code)
+	_, err = s.store.IncrementTotalClicks(r.Context(), codeData.code)
 	if err != nil {
 		// Redirect even if there is an error. Client should not suffer if the clicks can't be updated.
 		fmt.Fprintf(os.Stderr, "could not update TotalClick count: %v", err)
@@ -249,13 +259,13 @@ func (s *ShortyService) createLink(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *ShortyService) getLink(w http.ResponseWriter, r *http.Request) {
-	code := parseLinkCode(r.URL.Path)
-	link, err := s.store.FindLink(r.Context(), code)
+	codeData := parseLinkCode(r.URL.Path)
+	link, err := s.store.FindLink(r.Context(), codeData.code)
 	if err != nil {
 		if err == shorty.ErrLinkNotFound {
 			http.Error(
 				w,
-				fmt.Sprintf("Link not found: %q", code),
+				fmt.Sprintf("Link not found: %q", codeData.code),
 				http.StatusNotFound,
 			)
 			return
@@ -265,7 +275,7 @@ func (s *ShortyService) getLink(w http.ResponseWriter, r *http.Request) {
 		s.logError(fmt.Errorf("getLinks: FindLink: %v", err), s.getTrace(r))
 		http.Error(
 			w,
-			fmt.Sprintf("Could not retrieve link: %q\n", code),
+			fmt.Sprintf("Could not retrieve link: %q\n", codeData.code),
 			http.StatusInternalServerError,
 		)
 		return
@@ -310,8 +320,8 @@ func (s *ShortyService) updateLink(w http.ResponseWriter, r *http.Request) {
 		}
 		link.GenCode(s.baseURL)
 	}
-	code := parseLinkCode(r.URL.Path)
-	updated, err := s.store.UpdateLink(r.Context(), code, link)
+	codeData := parseLinkCode(r.URL.Path)
+	updated, err := s.store.UpdateLink(r.Context(), codeData.code, link)
 	if err != nil {
 		if err == shorty.ErrLinkNotFound {
 			http.Error(w, shorty.ErrLinkNotFound.Error(), http.StatusNotFound)
@@ -332,8 +342,8 @@ func (s *ShortyService) updateLink(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *ShortyService) deleteLink(w http.ResponseWriter, r *http.Request) {
-	code := parseLinkCode(r.URL.Path)
-	count, err := s.store.DeleteLink(r.Context(), code)
+	codeData := parseLinkCode(r.URL.Path)
+	count, err := s.store.DeleteLink(r.Context(), codeData.code)
 	if err != nil {
 		s.logError(fmt.Errorf("deleteLink: %v", err), s.getTrace(r))
 		http.Error(w, "Could not delete link", http.StatusInternalServerError)
@@ -342,8 +352,18 @@ func (s *ShortyService) deleteLink(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, count)
 }
 
-func parseLinkCode(URLPath string) string {
-	return strings.ReplaceAll(strings.TrimPrefix(URLPath, "/api/urls"), "/", "")
+func parseLinkCode(URLPath string) *ShortCodeData {
+	// parse code and tag from link path ex: /api/urls/abc123/tag
+	path := strings.TrimPrefix(URLPath, "/api/urls/")
+	path = strings.TrimPrefix(path, "/")
+	codes := strings.Split(path, "/")
+
+	codeData := &ShortCodeData{
+		code: codes[0],
+		tag:  codes[1],
+	}
+
+	return codeData
 }
 
 func validateURL(toShorten string) error {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -355,7 +355,6 @@ func parseLinkCode(URLPath string) *ShortCodeData {
 
 	codes := strings.Split(path, "/")
 
-	println("")
 	if len(codes) == 0 {
 		return &ShortCodeData{
 			code: "",

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -166,6 +166,11 @@ func (s *ShortyService) ServeResolver(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.URL.Path == "/" {
+		http.Redirect(w, r, "https://www.operationspark.org", http.StatusTemporaryRedirect)
+		return
+	}
+
 	code := parseLinkCode(r.URL.Path)
 	link, err := s.store.FindLink(r.Context(), code)
 	if err != nil {

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"testing"
 
+	"github.com/operationspark/shorty/shorty"
 	"github.com/operationspark/shorty/testutil"
 )
 
@@ -10,19 +11,19 @@ func TestParseLinkCode(t *testing.T) {
 	t.Run("grabs the Link code from the URL", func(t *testing.T) {
 		tests := []struct {
 			url  string
-			want *ShortCodeData
+			want shorty.ShortCodeData
 		}{
-			{"/api/urls", &ShortCodeData{code: "", tag: ""}},
-			{"/api/urls/", &ShortCodeData{code: "", tag: ""}},
-			{"/api/urls/abc123", &ShortCodeData{code: "abc123", tag: ""}},
-			{"/api/urls/abc123/", &ShortCodeData{code: "abc123", tag: ""}},
-			{"/api/urls/abc123/t-def456", &ShortCodeData{code: "abc123", tag: "t-def456"}},
+			{"/api/urls", shorty.ShortCodeData{Code: "", Tag: ""}},
+			{"/api/urls/", shorty.ShortCodeData{Code: "", Tag: ""}},
+			{"/api/urls/abc123", shorty.ShortCodeData{Code: "abc123", Tag: ""}},
+			{"/api/urls/abc123/", shorty.ShortCodeData{Code: "abc123", Tag: ""}},
+			{"/api/urls/abc123/t-def456", shorty.ShortCodeData{Code: "abc123", Tag: "t-def456"}},
 		}
 
 		for _, c := range tests {
 			got := parseLinkCode(c.url)
-			testutil.AssertEqual(t, got.code, c.want.code)
-			testutil.AssertEqual(t, got.tag, c.want.tag)
+			testutil.AssertEqual(t, got.Code, c.want.Code)
+			testutil.AssertEqual(t, got.Tag, c.want.Tag)
 		}
 	})
 }

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -10,17 +10,19 @@ func TestParseLinkCode(t *testing.T) {
 	t.Run("grabs the Link code from the URL", func(t *testing.T) {
 		tests := []struct {
 			url  string
-			want string
+			want *ShortCodeData
 		}{
-			{"/api/urls", ""},
-			{"/api/urls/", ""},
-			{"/api/urls/abc123", "abc123"},
-			{"/api/urls/abc123/", "abc123"},
+			{"/api/urls", &ShortCodeData{code: "", tag: ""}},
+			{"/api/urls/", &ShortCodeData{code: "", tag: ""}},
+			{"/api/urls/abc123", &ShortCodeData{code: "abc123", tag: ""}},
+			{"/api/urls/abc123/", &ShortCodeData{code: "abc123", tag: ""}},
+			{"/api/urls/abc123/t-def456", &ShortCodeData{code: "abc123", tag: "t-def456"}},
 		}
 
 		for _, c := range tests {
 			got := parseLinkCode(c.url)
-			testutil.AssertEqual(t, got, c.want)
+			testutil.AssertEqual(t, got.code, c.want.code)
+			testutil.AssertEqual(t, got.tag, c.want.tag)
 		}
 	})
 }

--- a/handlers/notFound.go
+++ b/handlers/notFound.go
@@ -33,9 +33,9 @@ func (s *ShortyService) renderNotFound(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	code := parseLinkCode(r.URL.Path)
+	codeData := parseLinkCode(r.URL.Path)
 	err = t.Execute(w, notFoundTemplateData{
-		Code:  code,
+		Code:  codeData.code,
 		Title: s.serviceName,
 	})
 	if err != nil {

--- a/handlers/notFound.go
+++ b/handlers/notFound.go
@@ -35,7 +35,7 @@ func (s *ShortyService) renderNotFound(w http.ResponseWriter, r *http.Request) {
 
 	codeData := parseLinkCode(r.URL.Path)
 	err = t.Execute(w, notFoundTemplateData{
-		Code:  codeData.code,
+		Code:  codeData.Code,
 		Title: s.serviceName,
 	})
 	if err != nil {

--- a/inmem/inmem.go
+++ b/inmem/inmem.go
@@ -110,3 +110,7 @@ func (i *Store) IncrementTotalClicks(ctx context.Context, code string) (int, err
 	}
 	return link.TotalClicks, nil
 }
+
+func (i *Store) AddTagActivity(ctx context.Context, codeData shorty.ShortCodeData) (int, error) {
+	return 0, nil
+}

--- a/mongodb/mongodb.go
+++ b/mongodb/mongodb.go
@@ -29,6 +29,7 @@ type (
 )
 
 // NewStore creates an empty Shorty store.
+// MongoDB Connection to database "url-shortener"
 func NewStore(o StoreOpts) (*Store, error) {
 	client, err := mongo.Connect(
 		context.TODO(),
@@ -79,10 +80,10 @@ func (i *Store) IncrementTotalClicks(ctx context.Context, code string) (int, err
 	coll := i.Client.Database(i.DBName).Collection(i.LinksCollName)
 	res, err := coll.UpdateOne(
 		ctx,
-		bson.D{{"code", code}},
+		bson.D{{Key: "code", Value: code}},
 		bson.D{
-			{"$inc", bson.D{{"totalClicks", 1}}},
-			{"$set", bson.D{{"updatedAt", time.Now()}}},
+			{Key: "$inc", Value: bson.D{{Key: "totalClicks", Value: 1}}},
+			{Key: "$set", Value: bson.D{{Key: "updatedAt", Value: time.Now()}}},
 		},
 	)
 	if err != nil {
@@ -99,7 +100,7 @@ func (i *Store) FindLink(ctx context.Context, code string) (shorty.Link, error) 
 	var link shorty.Link
 	coll := i.Client.Database(i.DBName).Collection(i.LinksCollName)
 
-	res := coll.FindOne(ctx, bson.D{{"code", code}})
+	res := coll.FindOne(ctx, bson.D{{Key: "code", Value: code}})
 	if res.Err() != nil {
 		if res.Err() == mongo.ErrNoDocuments {
 			return link, shorty.ErrLinkNotFound
@@ -133,23 +134,23 @@ func (i *Store) UpdateLink(ctx context.Context, code string, link shorty.Link) (
 	coll := i.Client.Database(i.DBName).Collection(i.LinksCollName)
 
 	updateDoc := bson.D{
-		{"updatedAt", time.Now()},
+		{Key: "updatedAt", Value: time.Now()},
 	}
 	if len(link.OriginalUrl) > 0 {
-		updateDoc = append(updateDoc, bson.E{"originalUrl", link.OriginalUrl})
+		updateDoc = append(updateDoc, bson.E{Key: "originalUrl", Value: link.OriginalUrl})
 	}
 
 	if len(link.CustomCode) > 0 {
 		updateDoc = append(updateDoc,
-			bson.E{"shortUrl", link.ShortURL},
-			bson.E{"code", link.Code},
-			bson.E{"customCode", link.CustomCode},
+			bson.E{Key: "shortUrl", Value: link.ShortURL},
+			bson.E{Key: "code", Value: link.Code},
+			bson.E{Key: "customCode", Value: link.CustomCode},
 		)
 	}
 	res, err := coll.UpdateOne(
 		ctx,
-		bson.D{{"code", code}},
-		bson.D{{"$set", updateDoc}},
+		bson.D{{Key: "code", Value: code}},
+		bson.D{{Key: "$set", Value: updateDoc}},
 	)
 
 	if err != nil {
@@ -164,7 +165,7 @@ func (i *Store) UpdateLink(ctx context.Context, code string, link shorty.Link) (
 // DeleteLink deletes a link from the database.
 func (i *Store) DeleteLink(ctx context.Context, code string) (int, error) {
 	coll := i.Client.Database(i.DBName).Collection(i.LinksCollName)
-	res, err := coll.DeleteOne(ctx, bson.D{{"code", code}})
+	res, err := coll.DeleteOne(ctx, bson.D{{Key: "code", Value: code}})
 	if err != nil {
 		return 0, fmt.Errorf("deleteOne: %v", err)
 	}

--- a/mongodb/mongodb.go
+++ b/mongodb/mongodb.go
@@ -75,26 +75,16 @@ func NewStore(o StoreOpts) (*Store, error) {
 	return &s, nil
 }
 
-// SaveTag inserts a new Tag into the database.
-func (i *Store) SaveTag(ctx context.Context, newTag shorty.Tag) (shorty.Tag, error) {
-	coll := i.Client.Database(i.DBName).Collection(i.TagsCollName)
-	_, err := coll.InsertOne(ctx, newTag)
-	if err != nil {
-		return shorty.Tag{}, fmt.Errorf("insertOne: %v", err)
-	}
-	return newTag, nil
-}
-
 // IncrementTotalClicks increments the "totalClicks" field and updates the database.
-func (i *Store) AddTagActivity(ctx context.Context, code string) (int, error) {
+func (i *Store) AddTagActivity(ctx context.Context, codeData shorty.ShortCodeData) (int, error) {
 	coll := i.Client.Database(i.DBName).Collection(i.TagsCollName)
 	res, err := coll.UpdateOne(
 		ctx,
-		bson.D{{Key: "code", Value: code}},
+		bson.D{{Key: "code", Value: codeData.Tag}},
 		bson.D{
 			{Key: "$push", Value: bson.D{{
 				Key:   "activity",
-				Value: bson.D{{Key: code, Value: time.Now()}},
+				Value: bson.D{{Key: codeData.Code, Value: time.Now()}},
 			}}},
 		},
 	)
@@ -105,47 +95,6 @@ func (i *Store) AddTagActivity(ctx context.Context, code string) (int, error) {
 		return 0, shorty.ErrLinkNotFound
 	}
 	return int(res.ModifiedCount), nil
-}
-
-func (i *Store) FindTag(ctx context.Context, code string) (shorty.Tag, error) {
-	var tag shorty.Tag
-	coll := i.Client.Database(i.DBName).Collection(i.TagsCollName)
-
-	res := coll.FindOne(ctx, bson.D{{Key: "code", Value: code}})
-	if res.Err() != nil {
-		if res.Err() == mongo.ErrNoDocuments {
-			return tag, shorty.ErrLinkNotFound
-		}
-		return tag, fmt.Errorf("Tags > findOne: %v", res.Err())
-	}
-
-	err := res.Decode(&tag)
-	if err != nil {
-		return tag, fmt.Errorf("decode: %v", err)
-	}
-	return tag, nil
-}
-
-func (i *Store) FindAllTags(ctx context.Context) (shorty.Tags, error) {
-	coll := i.Client.Database(i.DBName).Collection(i.TagsCollName)
-	cur, err := coll.Find(ctx, bson.D{{}})
-	if err != nil {
-		return shorty.Tags{}, fmt.Errorf("find: %v", err)
-	}
-	defer cur.Close(ctx)
-
-	tags := make(shorty.Tags, cur.RemainingBatchLength())
-	cur.All(ctx, &tags)
-	return tags, nil
-}
-
-func (i *Store) DeleteTag(ctx context.Context, code string) (int, error) {
-	coll := i.Client.Database(i.DBName).Collection(i.TagsCollName)
-	res, err := coll.DeleteOne(ctx, bson.D{{Key: "code", Value: code}})
-	if err != nil {
-		return 0, fmt.Errorf("deleteOne: %v", err)
-	}
-	return int(res.DeletedCount), nil
 }
 
 // SaveLink inserts a new Link into the database.

--- a/shorty/shortlink.go
+++ b/shorty/shortlink.go
@@ -11,23 +11,58 @@ type (
 	Link struct {
 		// Shortened URL result. Ex: https://ospk.org/bas12d21dc.
 		ShortURL string `json:"shortUrl" bson:"shortUrl"`
+
 		// Short Code used as the path of the short URL. Ex: bas12d21dc.
 		Code string `json:"code" bson:"code"`
+
 		// Optional custom short code passed when creating or updating the short URL.
 		CustomCode string `json:"customCode" bson:"customCode"`
+
 		// The URL where the short URL redirects.
 		OriginalUrl string `json:"originalUrl" bson:"originalUrl"`
+
 		// Count of times the short URL has been used.
 		TotalClicks int `json:"totalClicks" bson:"totalClicks"`
+
 		// Identifier of the entity that created the short URL.
 		CreatedBy string `json:"createdBy" bson:"createdBy"`
+
 		// DateTime the URL was created.
 		CreatedAt time.Time `json:"createdAt" bson:"createdAt"`
+
 		// DateTime the URL was last updated.
 		UpdatedAt time.Time `json:"updatedAt" bson:"updatedAt"`
 	}
 
 	Links []*Link
+
+	Tag struct {
+		// Short Code used as the optional second param of the short URL path. Ex: /:shortCode/abc123
+		//  /:shortCode/:tagCode
+		Code string `json:"code" bson:"code"`
+
+		// List of click/url history for the tag.
+		Activity []struct {
+			// DateTime the tag was created.
+			CreatedAt time.Time `json:"createdAt" bson:"createdAt"`
+
+			// Short URL code used
+			ShortCode string `json:"shortCode" bson:"shortCode"`
+		} `json:"activity" bson:"activity"`
+
+		Data map[string]interface{} `json:"data" bson:"data"`
+
+		// Identifier of the entity that created the short URL.
+		CreatedBy string `json:"createdBy" bson:"createdBy"`
+
+		// DateTime the tag was created.
+		CreatedAt time.Time `json:"createdAt" bson:"createdAt"`
+
+		// DateTime the tag was last updated.
+		UpdatedAt time.Time `json:"updatedAt" bson:"updatedAt"`
+	}
+
+	Tags []*Tag
 )
 
 // FromJSON unmarshals a request's JSON body into a Link.

--- a/shorty/shortlink.go
+++ b/shorty/shortlink.go
@@ -63,6 +63,11 @@ type (
 	}
 
 	Tags []*Tag
+
+	ShortCodeData struct {
+		Code string
+		Tag  string
+	}
 )
 
 // FromJSON unmarshals a request's JSON body into a Link.


### PR DESCRIPTION
## WIP: Initial idea for url tagging

- Accepts optional tag in URL
  - `/:code/:tag?`
 
examples

### Resolve the second param as `tag` code
#### TODO:
- [ ] Create `Tags` collection
- [ ] Add a "tag" when we want to correlate user to link (where and how I'm not sure, maybe through this API we can allow some reference.. I think we should discuss this)
  - Tags should contain a reference to the user, email, and short link
```
Path: /code/tagcode
Resolved  → `{ code: "code", tag: "tagcode"}`
```

```
Path: /abc123/zyx987
Resolved  → `{ code: "abc123", tag: "zyx987"}`
```

### Resolves tag as empty string if it doesn't exist
```
Path: /abc123
Resolved  → `{ code: "abc123", tag: "" }`
```

### Ignores extra params
```
Path: /abc123/zyx987/ignored
Resolved  → `{ code: "abc123", tag: "456" }`
```


### Fix lint errors to specify key
<img width="911" alt="Screenshot 2023-08-26 at 8 18 54 PM" src="https://github.com/OperationSpark/service-shorty/assets/37914211/85defa6f-49f6-4577-b01a-fb7077f9a8ce">


